### PR TITLE
[MIG] hr_timesheet_attendance_ux: Migration to 15.0

### DIFF
--- a/hr_timesheet_attendance_ux/__manifest__.py
+++ b/hr_timesheet_attendance_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Attendance Timesheet UX",
-    'version': '13.0.1.0.0',
+    'version': "15.0.1.0.0",
     'category': 'Human Resources',
     'sequence': 14,
     'author': 'ADHOC SA',
@@ -37,7 +37,7 @@
     'qweb': [
         "static/src/xml/attendance.xml",
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': False,
     'application': False,
 }


### PR DESCRIPTION
The domain to filter task by project in v15 was given in the definition of the task_id field.
Adhoc add the domain: task in folded stage are ignored