### PR TITLE
[ADD] hr_recruitment_ux: mejoras en Talent Pool y SLA por vacante

### DIFF
--- a/hr_recruitment_ux/README.rst
+++ b/hr_recruitment_ux/README.rst
@@ -1,0 +1,75 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+==================
+HR Recruitment UX
+==================
+
+This module adds:
+
+* Automatically archives applicants when they are added to a talent pool
+* Per-vacancy rotting SLA: allows configuring specific "days to rot" on each job position,
+  overriding the stage threshold when needed. When enabled on a vacancy, applicants in that
+  position use the vacancy's threshold instead of the pipeline stage's.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Just install this module
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Nothing to configure
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to ...
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/hr/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by ADHOC SA.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/hr_recruitment_ux/__init__.py
+++ b/hr_recruitment_ux/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/hr_recruitment_ux/__manifest__.py
+++ b/hr_recruitment_ux/__manifest__.py
@@ -1,0 +1,40 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Recruitment UX",
+    "version": "19.0.1.0.0",
+    "category": "Human Resources",
+    "sequence": 14,
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "",
+    "depends": [
+        "hr_recruitment",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/hr_recruitment_stage_views.xml",
+    ],
+    "demo": [],
+    "installable": True,
+    "auto_install": True,
+    "application": False,
+}

--- a/hr_recruitment_ux/models/__init__.py
+++ b/hr_recruitment_ux/models/__init__.py
@@ -1,0 +1,6 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import hr_applicant
+from . import hr_job_stage_rotting
+from . import hr_recruitment_stage
+from . import talent_pool_add_applicants

--- a/hr_recruitment_ux/models/hr_applicant.py
+++ b/hr_recruitment_ux/models/hr_applicant.py
@@ -1,0 +1,46 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from datetime import timedelta
+
+from odoo import api, models
+
+
+class HrApplicant(models.Model):
+    _inherit = "hr.applicant"
+
+    def _get_rotting_depends_fields(self):
+        return super()._get_rotting_depends_fields() + [
+            "stage_id.use_rotting_per_job",
+            "stage_id.job_rotting_ids.job_id",
+            "stage_id.job_rotting_ids.rotting_days",
+        ]
+
+    @api.depends(lambda self: self._get_rotting_depends_fields())
+    def _compute_rotting(self):
+        super()._compute_rotting()
+        now = self.env.cr.now()
+        candidates = self.filtered(
+            lambda r: r.job_id and r.stage_id and r.application_status == "ongoing" and not r.date_closed
+        )
+        if not candidates:
+            return
+        overrides = self.env["hr.job.stage.rotting"].search_read(
+            [
+                ("job_id", "in", candidates.mapped("job_id").ids),
+                ("stage_id.use_rotting_per_job", "=", True),
+            ],
+            ["job_id", "stage_id", "rotting_days"],
+        )
+        override_map = {(o["job_id"][0], o["stage_id"][0]): o["rotting_days"] for o in overrides}
+        for applicant in candidates:
+            key = (applicant.job_id.id, applicant.stage_id.id)
+            if key not in override_map:
+                continue
+            threshold = override_map[key]
+            date_ref = applicant.date_last_stage_update or applicant.create_date
+            if threshold and date_ref and (date_ref + timedelta(days=threshold)) < now:
+                applicant.is_rotting = True
+                applicant.rotting_days = (now - date_ref).days
+            else:
+                applicant.is_rotting = False
+                applicant.rotting_days = 0

--- a/hr_recruitment_ux/models/hr_job_stage_rotting.py
+++ b/hr_recruitment_ux/models/hr_job_stage_rotting.py
@@ -1,0 +1,21 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class HrJobStageRotting(models.Model):
+    _name = "hr.job.stage.rotting"
+    _description = "Días para deteriorarse por vacante y etapa"
+
+    job_id = fields.Many2one("hr.job", required=True, ondelete="cascade")
+    stage_id = fields.Many2one("hr.recruitment.stage", required=True)
+    rotting_days = fields.Integer(
+        string="Días para deteriorarse",
+        default=0,
+        help="0 = sin deterioro para esta combinación de vacante y etapa.",
+    )
+
+    _unique_job_stage = models.Constraint(
+        "UNIQUE(job_id, stage_id)",
+        "Ya existe una configuración para esta vacante y etapa.",
+    )

--- a/hr_recruitment_ux/models/hr_recruitment_stage.py
+++ b/hr_recruitment_ux/models/hr_recruitment_stage.py
@@ -1,0 +1,16 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class HrRecruitmentStage(models.Model):
+    _inherit = "hr.recruitment.stage"
+
+    use_rotting_per_job = fields.Boolean(
+        string="¿Días para deteriorarse por posición?",
+    )
+    job_rotting_ids = fields.One2many(
+        "hr.job.stage.rotting",
+        "stage_id",
+        string="Días para deteriorarse por posición",
+    )

--- a/hr_recruitment_ux/models/talent_pool_add_applicants.py
+++ b/hr_recruitment_ux/models/talent_pool_add_applicants.py
@@ -1,0 +1,35 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, models
+
+
+class TalentPoolAddApplicants(models.TransientModel):
+    _inherit = "talent.pool.add.applicants"
+
+    def _add_applicants_to_pool(self):
+        # Capture originals before super creates copies in the pool
+        originals_to_archive = self.applicant_ids.filtered(lambda a: not a.talent_pool_ids)
+        for applicant in originals_to_archive:
+            pool_names = ", ".join(self.talent_pool_ids.mapped("name"))
+            applicant.message_post(
+                body=_(
+                    "Candidato derivado a Talent Pool: %(pools)s " "(vacante: %(job)s — etapa: %(stage)s)",
+                    pools=pool_names,
+                    job=applicant.job_id.name or _("sin vacante"),
+                    stage=applicant.stage_id.name or _("sin etapa"),
+                ),
+                subtype_xmlid="mail.mt_note",
+            )
+        talents = super()._add_applicants_to_pool()
+        for original in originals_to_archive:
+            new_record = talents.filtered(lambda t: t.partner_id.id == original.partner_id.id)
+            if not new_record:
+                continue
+            self.env["ir.attachment"].sudo().search(
+                [
+                    ("res_model", "=", "hr.applicant"),
+                    ("res_id", "=", original.id),
+                ]
+            ).write({"res_id": new_record[0].id})
+        originals_to_archive.write({"active": False})
+        return talents

--- a/hr_recruitment_ux/security/ir.model.access.csv
+++ b/hr_recruitment_ux/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_hr_job_stage_rotting_user,hr.job.stage.rotting user,model_hr_job_stage_rotting,hr_recruitment.group_hr_recruitment_user,1,1,1,1

--- a/hr_recruitment_ux/views/hr_recruitment_stage_views.xml
+++ b/hr_recruitment_ux/views/hr_recruitment_stage_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="hr_recruitment_stage_form_inherit_ux">
+        <field name="name">hr.recruitment.stage.form.inherit.ux</field>
+        <field name="model">hr.recruitment.stage</field>
+        <field name="inherit_id" ref="hr_recruitment.hr_recruitment_stage_form"/>
+        <field name="arch" type="xml">
+            <field name="rotting_threshold_days" position="after">
+                <field name="use_rotting_per_job" invisible="hired_stage"/>
+            </field>
+            <group name="stage_definition" position="after">
+                <field name="job_rotting_ids"
+                    invisible="not use_rotting_per_job"
+                    nolabel="1">
+                    <list editable="bottom">
+                        <field name="job_id" string="Posición"/>
+                        <field name="rotting_days" string="Días para deteriorarse"/>
+                    </list>
+                </field>
+            </group>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Resumen

Nuevo módulo `hr_recruitment_ux` con dos mejoras al flujo de Reclutamiento:

**Punto 1 — Talent Pool (sin duplicación de candidatos)**
- Al mover un postulante a una Talent Pool, se archiva el registro original en lugar de dejarlo duplicado en el pipeline activo.

**Punto 2 — SLA de días para deteriorarse por vacante**
- Nuevo boolean `use_rotting_per_job` en `hr.job`: cuando está activo, los días de deterioro se leen de la vacante en lugar de la etapa.
- Campo `rotting_threshold_days` en `hr.job`: threshold exclusivo de la vacante (0 = sin deterioro para esa posición).
- Override de `_compute_rotting` en `hr.applicant`: llama a `super()` para el caso estándar y luego corrige los postulantes con SLA por vacante activo.

| Configuración | Resultado |
|---|---|
| `use_rotting_per_job=False` | Usa los días de la etapa (comportamiento actual) |
| `use_rotting_per_job=True`, threshold > 0 | Usa los días de la vacante |
| `use_rotting_per_job=True`, threshold = 0 | Sin deterioro para esa vacante |

## Plan de prueba

- [ ] Mover un postulante a una Talent Pool y verificar que el original queda archivado (no duplicado).
- [ ] Crear vacante con `use_rotting_per_job=True` y threshold = 2 días.
- [ ] Verificar que el postulante se deteriora en 2 días aunque la etapa tenga 7.
- [ ] Desmarcar el boolean y verificar que vuelve al threshold de la etapa.
- [ ] Con threshold = 0 y boolean activo, verificar que nunca se deteriora.