### PR TITLE
[IMP] hr_holidays_ux: prevent auto-approval in batch allocations

### DIFF
--- a/hr_holidays_ux/__init__.py
+++ b/hr_holidays_ux/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/hr_holidays_ux/__manifest__.py
+++ b/hr_holidays_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Holidays UX",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "category": "Human Resources",
     "sequence": 14,
     "summary": "Split time off records by month",
@@ -31,6 +31,7 @@
         "hr_holidays",
     ],
     "data": [
+        "data/ir_actions_server.xml",
         "views/hr_leave_type_views.xml",
         "views/hr_leave_views.xml",
     ],

--- a/hr_holidays_ux/data/ir_actions_server.xml
+++ b/hr_holidays_ux/data/ir_actions_server.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="action_reset_allocation_to_confirm" model="ir.actions.server">
+        <field name="name">Reset to "To Approve"</field>
+        <field name="model_id" ref="hr_holidays.model_hr_leave_allocation"/>
+        <field name="binding_model_id" ref="hr_holidays.model_hr_leave_allocation"/>
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">records.action_reset_to_confirm()</field>
+    </record>
+</odoo>

--- a/hr_holidays_ux/models/__init__.py
+++ b/hr_holidays_ux/models/__init__.py
@@ -1,2 +1,3 @@
 from . import hr_leave
+from . import hr_leave_allocation
 from . import hr_leave_type

--- a/hr_holidays_ux/models/hr_leave_allocation.py
+++ b/hr_holidays_ux/models/hr_leave_allocation.py
@@ -1,0 +1,22 @@
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class HrLeaveAllocation(models.Model):
+    _inherit = "hr.leave.allocation"
+
+    def action_reset_to_confirm(self):
+        """Revert validated allocations back to 'To Approve' (confirm) state.
+
+        Blocked when any selected allocation has leaves already taken, since
+        reverting the approval would make those days go into deficit.
+        Permission checks (officer/manager role) are enforced by
+        _check_approval_update inside write().
+        """
+        blocked = self.filtered(lambda a: a.leaves_taken > 0)
+        if blocked:
+            raise UserError(
+                _("The following allocations already have leaves taken and cannot be reset:\n%s")
+                % "\n".join(blocked.mapped("display_name"))
+            )
+        self.filtered(lambda a: a.state in ("validate", "validate1")).write({"state": "confirm"})

--- a/hr_holidays_ux/wizard/__init__.py
+++ b/hr_holidays_ux/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_leave_allocation_generate_multi_wizard

--- a/hr_holidays_ux/wizard/hr_leave_allocation_generate_multi_wizard.py
+++ b/hr_holidays_ux/wizard/hr_leave_allocation_generate_multi_wizard.py
@@ -1,0 +1,46 @@
+from datetime import date
+
+from odoo import models
+
+
+class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
+    _inherit = "hr.leave.allocation.generate.multi.wizard"
+
+    def action_generate_allocations(self):
+        """Override to prevent auto-approval after batch creation.
+
+        Upstream calls action_approve() right after create(), bypassing the
+        validation flow configured on the leave type.  We reproduce the method
+        without those calls so allocations land in 'confirm' (To Approve).
+        no_validation types still auto-approve via the create() hook in
+        hr.leave.allocation.
+        """
+        self.ensure_one()
+        employees = self._get_employees_from_allocation_mode()
+        vals_list = self._prepare_allocation_values(employees)
+        if not vals_list:
+            return None
+        allocations = (
+            self.env["hr.leave.allocation"]
+            .with_context(
+                mail_notify_force_send=False,
+                mail_activity_automation_skip=True,
+            )
+            .create(vals_list)
+        )
+        accrual_allocations = allocations.filtered(lambda a: a.allocation_type == "accrual")
+        for date_to, allocation in accrual_allocations.grouped("date_to").items():
+            date_to = min(date_to, date.today()) if date_to else False
+            allocation._process_accrual_plans(date_to)
+        return {
+            "type": "ir.actions.act_window",
+            "name": self.env._("Generated Allocations"),
+            "views": [
+                [self.env.ref("hr_holidays.hr_leave_allocation_view_tree").id, "list"],
+                [self.env.ref("hr_holidays.hr_leave_allocation_view_form_manager").id, "form"],
+            ],
+            "view_mode": "list",
+            "res_model": "hr.leave.allocation",
+            "domain": [("id", "in", allocations.ids)],
+            "context": {"active_id": False},
+        }


### PR DESCRIPTION
## Summary

- Override `action_generate_allocations` on `hr.leave.allocation.generate.multi.wizard` so allocations created via "New Group Allocation" stay in `confirm` (To Approve) instead of being auto-approved. Types with `no_validation` still auto-approve via the `create()` hook.
- Add `action_reset_to_confirm` on `hr.leave.allocation` to revert validated allocations back to `confirm`. Raises `UserError` if `leaves_taken > 0`; permission checks delegated to `_check_approval_update`.
- Add server action bound to the allocation list view (Actions menu) to expose `action_reset_to_confirm`.

## Test plan

- [ ] Open "New Group Allocation" wizard, fill in a leave type with validation "By Time Off Officer", generate → allocations should land in "To Approve" (not "Approved").
- [ ] For a leave type with "No Validation", same wizard → allocations still auto-approve.
- [ ] From the allocation list, select approved allocations with no leaves taken → Actions → "Reset to To Approve" → state changes to confirm.
- [ ] Same action on an allocation with `leaves_taken > 0` → UserError raised.
- [ ] Same action as a non-officer user → `UserError` from `_check_approval_update`.

Related task: https://www.adhoc.inc/odoo/knowledge/180/902/tasks/64815