### PR TITLE
[ADD] website_hr_recruitment_ux: phone min-length validation on job application form

### DIFF
--- a/website_hr_recruitment_ux/__manifest__.py
+++ b/website_hr_recruitment_ux/__manifest__.py
@@ -1,0 +1,43 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Website HR Recruitment UX",
+    "version": "19.0.1.0.0",
+    "category": "Human Resources",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "Fixes phone field validation in the public job application form",
+    "depends": [
+        "hr_recruitment_ux",
+        "website_hr_recruitment",
+    ],
+    "data": [
+        "views/website_hr_recruitment_templates.xml",
+    ],
+    "assets": {
+        "web.assets_frontend": [
+            "website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js",
+        ],
+    },
+    "auto_install": True,
+    "installable": True,
+    "application": False,
+}

--- a/website_hr_recruitment_ux/__manifest__.py
+++ b/website_hr_recruitment_ux/__manifest__.py
@@ -26,7 +26,6 @@
     "license": "AGPL-3",
     "summary": "Fixes phone field validation in the public job application form",
     "depends": [
-        "hr_recruitment_ux",
         "website_hr_recruitment",
     ],
     "data": [

--- a/website_hr_recruitment_ux/i18n/es.po
+++ b/website_hr_recruitment_ux/i18n/es.po
@@ -1,0 +1,21 @@
+# Spanish translation of website_hr_recruitment_ux.
+# Copyright (C) 2026 ADHOC SA
+# This file is distributed under the same license as the website_hr_recruitment_ux package.
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-19 00:00+0000\n"
+"PO-Revision-Date: 2026-06-19 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: es <es@li.org>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: website_hr_recruitment_ux
+#: website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js:0
+msgid "Please enter a valid phone number."
+msgstr "Por favor ingresá un número de teléfono válido."

--- a/website_hr_recruitment_ux/i18n/es.po
+++ b/website_hr_recruitment_ux/i18n/es.po
@@ -16,6 +16,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: website_hr_recruitment_ux
-#: website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js:0
+#: code:addons/website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js:0
 msgid "Please enter a valid phone number."
 msgstr "Por favor ingresá un número de teléfono válido."

--- a/website_hr_recruitment_ux/i18n/website_hr_recruitment_ux.pot
+++ b/website_hr_recruitment_ux/i18n/website_hr_recruitment_ux.pot
@@ -16,6 +16,6 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: website_hr_recruitment_ux
-#: website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js:0
+#: code:addons/website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js:0
 msgid "Please enter a valid phone number."
 msgstr ""

--- a/website_hr_recruitment_ux/i18n/website_hr_recruitment_ux.pot
+++ b/website_hr_recruitment_ux/i18n/website_hr_recruitment_ux.pot
@@ -1,0 +1,21 @@
+# Translation of website_hr_recruitment_ux.pot.
+# Copyright (C) 2026 ADHOC SA
+# This file is distributed under the same license as the website_hr_recruitment_ux package.
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-19 00:00+0000\n"
+"PO-Revision-Date: 2026-06-19 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: website_hr_recruitment_ux
+#: website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js:0
+msgid "Please enter a valid phone number."
+msgstr ""

--- a/website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js
+++ b/website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js
@@ -1,0 +1,14 @@
+import { HrRecruitmentForm } from "@website_hr_recruitment/interactions/hr_recruitment_form";
+import { patch } from "@web/core/utils/patch";
+
+const MIN_PHONE_LENGTH = 7;
+
+patch(HrRecruitmentForm.prototype, {
+    async checkRedundant(targetEl, field, messageContainerEl, keepPreviousWarningMessage = false) {
+        if (field === "phone" && targetEl.value && targetEl.value.length < MIN_PHONE_LENGTH) {
+            this.hideWarningMessage(targetEl, messageContainerEl);
+            return;
+        }
+        return super.checkRedundant(targetEl, field, messageContainerEl, keepPreviousWarningMessage);
+    },
+});

--- a/website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js
+++ b/website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js
@@ -1,12 +1,17 @@
 import { HrRecruitmentForm } from "@website_hr_recruitment/interactions/hr_recruitment_form";
 import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
 
 const MIN_PHONE_LENGTH = 7;
 
 patch(HrRecruitmentForm.prototype, {
     async checkRedundant(targetEl, field, messageContainerEl, keepPreviousWarningMessage = false) {
         if (field === "phone" && targetEl.value && targetEl.value.length < MIN_PHONE_LENGTH) {
-            this.hideWarningMessage(targetEl, messageContainerEl);
+            this.showWarningMessage(
+                targetEl,
+                messageContainerEl,
+                _t("Please enter a valid phone number.")
+            );
             return;
         }
         return super.checkRedundant(targetEl, field, messageContainerEl, keepPreviousWarningMessage);

--- a/website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js
+++ b/website_hr_recruitment_ux/static/src/interactions/hr_recruitment_form.js
@@ -5,6 +5,19 @@ import { _t } from "@web/core/l10n/translation";
 const MIN_PHONE_LENGTH = 7;
 
 patch(HrRecruitmentForm.prototype, {
+    setup() {
+        super.setup();
+        const phoneEl = this.el.querySelector("#recruitment3");
+        if (phoneEl) {
+            phoneEl.addEventListener("invalid", () => {
+                if (phoneEl.validity.tooShort) {
+                    phoneEl.setCustomValidity(_t("Please enter a valid phone number."));
+                }
+            });
+            phoneEl.addEventListener("input", () => phoneEl.setCustomValidity(""));
+        }
+    },
+
     async checkRedundant(targetEl, field, messageContainerEl, keepPreviousWarningMessage = false) {
         if (field === "phone" && targetEl.value && targetEl.value.length < MIN_PHONE_LENGTH) {
             this.showWarningMessage(

--- a/website_hr_recruitment_ux/views/website_hr_recruitment_templates.xml
+++ b/website_hr_recruitment_ux/views/website_hr_recruitment_templates.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Add minimum length to the phone field to block submissions with only a country prefix (e.g. +54) -->
+    <template id="apply_phone_minlength" inherit_id="website_hr_recruitment.apply">
+        <xpath expr="//input[@name='partner_phone']" position="attributes">
+            <attribute name="minlength">7</attribute>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Summary

Adds the `website_hr_recruitment_ux` module to fix a bug in the public job application form where the phone field could be submitted containing only a country prefix (e.g. `+54`), causing two cascading issues:

1. **False "already applied" warning** — `check_recent_application` uses exact equality on the raw `partner_phone` value, so every applicant who submitted `+54` matches every other, triggering the duplicate-application message incorrectly.
2. **Inflated `application_count`** — `_compute_partner_phone_sanitized` falls back to the raw value when `_phone_format` cannot parse a bare prefix, causing `_compute_application_count` to group unrelated applicants together.

### Changes

- **Template override** (`views/website_hr_recruitment_templates.xml`): inherits `website_hr_recruitment.apply` and adds `minlength="7"` to the `partner_phone` input. The browser blocks form submission when only the auto-filled country prefix is present.
- **JS patch** (`static/src/interactions/hr_recruitment_form.js`): patches `HrRecruitmentForm.checkRedundant` to skip the RPC call when the phone value is shorter than 7 characters, preventing the false "already applied" toast from firing on `focusout`.

The module depends on `hr_recruitment_ux` + `website_hr_recruitment` and uses `auto_install: True` so it activates automatically whenever both are present.

## Test plan

1. Navigate to a public job offer page on the website.
2. Fill in Name and Email, leave the Phone field with only the auto-filled country prefix (e.g. `+54`).
3. Tab out of the Phone field — verify **no** "already applied" warning appears.
4. Click the Apply button — verify the browser shows a native validation error on the Phone field and the form is **not submitted**.
5. Enter a complete phone number (e.g. `+54 9 11 1234-5678`) and submit — verify the application goes through normally.