### PR TITLE
[FIX] hr_recruitment_ux: add read access to hr.job.stage.rotting for interviewer group

### DIFF
--- a/hr_recruitment_ux/security/ir.model.access.csv
+++ b/hr_recruitment_ux/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_hr_job_stage_rotting_user,hr.job.stage.rotting user,model_hr_job_stage_rotting,hr_recruitment.group_hr_recruitment_user,1,1,1,1
+access_hr_job_stage_rotting_interviewer,hr.job.stage.rotting interviewer,model_hr_job_stage_rotting,hr_recruitment.group_hr_recruitment_interviewer,1,0,0,0


### PR DESCRIPTION
## Summary
- Faltaba ACL de lectura para `hr_recruitment.group_hr_recruitment_interviewer` en el modelo `hr.job.stage.rotting`
- La vista de postulaciones intenta leer este modelo al cargar, causando un "Error de acceso" para cualquier usuario con solo el rol Entrevistador
- Fix: una línea read-only en `ir.model.access.csv` para el grupo interviewer

## Test plan
- [ ] Loguear como usuario con grupo Entrevistador (sin Officer)
- [ ] Acceder a Reclutamiento → Postulantes → verificar que no aparece "Error de acceso"
- [ ] Verificar que el usuario solo ve postulaciones de las vacantes donde está asignado como entrevistador

Closes helpdesk ticket #121071

🤖 Generated with [Claude Code](https://claude.com/claude-code)